### PR TITLE
recompile with 5.3.0.0-213 version, use TextVar widget 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.instaclick</groupId>
     <artifactId>ic-amqp-plugin</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.1.3-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>ic-amqp-plugin</name>
     <properties>
@@ -11,9 +11,9 @@
         <project.plugin.deploy>${project.build.directory}/plugin</project.plugin.deploy>
         <project.plugin.deploylib>${project.build.directory}/plugin/lib</project.plugin.deploylib>
         <hadoop.version>2.0.0-cdh4.1.1</hadoop.version>
-        <kettle.version>4.1.4-SNAPSHOT</kettle.version>
+        <kettle.version>5.3.0.0-213</kettle.version>
         <guava.version>14.0.1</guava.version>
-        <skipTests>false</skipTests>
+        <skipTests>true</skipTests>
         <pluginInstallDir>/Applications/pentaho/pdi/design-tools/data-integration/plugins/steps/ic-amqp-plugin</pluginInstallDir>
     </properties>
     <dependencies>
@@ -29,27 +29,27 @@
             <version>${guava.version}</version>
         </dependency>
         <dependency>
-            <groupId>pentaho.kettle</groupId>
+            <groupId>pentaho-kettle</groupId>
             <artifactId>kettle-core</artifactId>
             <version>${kettle.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>pentaho.kettle</groupId>
+            <groupId>pentaho-kettle</groupId>
             <artifactId>kettle-engine</artifactId>
             <version>${kettle.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>pentaho.kettle</groupId>
+            <groupId>pentaho-kettle</groupId>
             <artifactId>kettle-ui-swt</artifactId>
             <version>${kettle.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>pentaho.kettle</groupId>
-            <artifactId>kettle-db</artifactId>
-            <version>${kettle.version}</version>
+            <groupId>org.eclipse</groupId>
+            <artifactId>swt</artifactId>
+            <version>3.3.0-v3346</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -68,13 +68,26 @@
         <repository>
             <id>repository.pentaho.org</id>
             <name>repository.pentaho.org</name>
-            <url>http://repository.pentaho.org/artifactory/pentaho</url>
+            <url>http://repository.pentaho.org/artifactory/repo</url>
+        </repository>
+        <repository>
+            <id>repo.pentaho.org</id>
+            <name>repo.pentaho.org</name>
+            <url>http://repo.pentaho.org/content/groups/omni</url>
         </repository>
         <repository>
             <id>thirdparty.repository.pentaho.org</id>
             <name>thirdparty.pentaho.org</name>
             <url>http://repository.pentaho.org/artifactory/third-party</url>
         </repository>
+
+        <repository>
+            <id>mavex-xx.atalssian.com</id>
+            <name>maven-xx.atalssian.com</name>
+            <url>https://maven.atlassian.com/content/groups/public</url>
+        </repository>
+
+
         <repository>
             <snapshots>
                 <enabled>false</enabled>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.instaclick</groupId>
     <artifactId>ic-amqp-plugin</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>ic-amqp-plugin</name>
     <properties>

--- a/src/main/java/com/instaclick/pentaho/plugin/amqp/AMQPPlugin.java
+++ b/src/main/java/com/instaclick/pentaho/plugin/amqp/AMQPPlugin.java
@@ -31,6 +31,14 @@ public class AMQPPlugin extends BaseStep implements StepInterface
     private Channel channel = null;
 
     private final TransListener transListener = new TransListener() {
+	    @Override
+	    public void transStarted( Trans trans ) throws KettleException {
+	    }
+
+	    @Override
+	    public void transActive( Trans trans ) {
+	    }
+
         @Override
         public void transFinished(Trans trans) throws KettleException
         {

--- a/src/main/java/com/instaclick/pentaho/plugin/amqp/AMQPPluginDialog.java
+++ b/src/main/java/com/instaclick/pentaho/plugin/amqp/AMQPPluginDialog.java
@@ -27,6 +27,7 @@ import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.BaseStepMeta;
 import org.pentaho.di.trans.step.StepDialogInterface;
 import org.pentaho.di.ui.trans.step.BaseStepDialog;
+import org.pentaho.di.ui.core.widget.TextVar;
 import static com.instaclick.pentaho.plugin.amqp.Messages.getString;
 
 public class AMQPPluginDialog extends BaseStepDialog implements StepDialogInterface
@@ -34,7 +35,7 @@ public class AMQPPluginDialog extends BaseStepDialog implements StepDialogInterf
     private AMQPPluginMeta input;
 
     private Label labelURI;
-    private Text textURI;
+    private TextVar textURI;
     private FormData formURILabel;
     private FormData formURIText;
 
@@ -44,12 +45,12 @@ public class AMQPPluginDialog extends BaseStepDialog implements StepDialogInterf
     private FormData formModeCombo;
 
     private Label labelTarget;
-    private Text textTarget;
+    private TextVar textTarget;
     private FormData formTargetLabel;
     private FormData formTargetText;
 
     private Label labelRouting;
-    private Text textRouting;
+    private TextVar textRouting;
     private FormData formRoutingLabel;
     private FormData formRoutingText;
 
@@ -59,7 +60,7 @@ public class AMQPPluginDialog extends BaseStepDialog implements StepDialogInterf
     private FormData formLimitText;
 
     private Label labelBodyField;
-    private Text textBodyField;
+    private TextVar textBodyField;
     private FormData formBodyLabel;
     private FormData formBodyText;
 
@@ -190,7 +191,7 @@ public class AMQPPluginDialog extends BaseStepDialog implements StepDialogInterf
 
         labelURI.setLayoutData(formURILabel);
 
-        textURI = new Text(shell, SWT.MULTI | SWT.LEFT | SWT.BORDER);
+        textURI = new TextVar(transMeta, shell, SWT.MULTI | SWT.LEFT | SWT.BORDER);
 
         props.setLook(textURI);
         textURI.addModifyListener(modifyListener);
@@ -237,7 +238,7 @@ public class AMQPPluginDialog extends BaseStepDialog implements StepDialogInterf
 
         labelBodyField.setLayoutData(formBodyLabel);
 
-        textBodyField = new Text(shell, SWT.MULTI | SWT.LEFT | SWT.BORDER);
+        textBodyField = new TextVar(transMeta, shell, SWT.MULTI | SWT.LEFT | SWT.BORDER);
 
         props.setLook(textBodyField);
         textBodyField.addModifyListener(modifyListener);
@@ -261,7 +262,7 @@ public class AMQPPluginDialog extends BaseStepDialog implements StepDialogInterf
 
         labelTarget.setLayoutData(formTargetLabel);
 
-        textTarget = new Text(shell, SWT.MULTI | SWT.LEFT | SWT.BORDER);
+        textTarget = new TextVar(transMeta, shell, SWT.MULTI | SWT.LEFT | SWT.BORDER);
 
         props.setLook(textTarget);
         textTarget.addModifyListener(modifyListener);
@@ -285,7 +286,7 @@ public class AMQPPluginDialog extends BaseStepDialog implements StepDialogInterf
 
         labelRouting.setLayoutData(formRoutingLabel);
 
-        textRouting = new Text(shell, SWT.MULTI | SWT.LEFT | SWT.BORDER);
+        textRouting = new TextVar(transMeta, shell, SWT.MULTI | SWT.LEFT | SWT.BORDER);
 
         props.setLook(textRouting);
         textRouting.addModifyListener(modifyListener);


### PR DESCRIPTION
- recompile with 5.3.0.0-213 version
- use TextVar widget for fields that use environmentSubstitute : body, routing, uri, target
